### PR TITLE
Fix: Update readme with correct import

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ dependencies:
 In your project, just wrap the `ColorScheme.dark(...)` with `colorBlindnessColorScheme()`.
 
 ```dart
-import 'package:random_colorscheme/color_blindness_color_scheme.dart';
+import 'package:color_blindness/color_blindness.dart';
+import 'package:color_blindness/color_blindness_color_scheme.dart';
 
 Theme(
   data: ThemeData(


### PR DESCRIPTION
Replaced an old import in Readme with the correct one.

Please consider adding the export `export 'package:color_blindness/color_blindness_color_scheme.dart';` in `color_blindess.dart` to avoid the double import in most use cases

